### PR TITLE
Winterfell codegen and CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
   "air-dsl",
   "parser",
-  "ir"
+  "ir",
+  "codegen-winter"
 ]

--- a/air-dsl/Cargo.toml
+++ b/air-dsl/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
+parser = { package = "parser", path = "../parser", version = "0.0.1" }
+ir = { package = "ir", path = "../ir", version = "0.0.1" }
+codegen-winter = { package = "codegen-winter", path = "../codegen-winter", version = "0.1.0" }
+structopt = "0.3.26"
+env_logger = "0.9"
+log = { version = "0.4", default-features = false }

--- a/air-dsl/src/cli/mod.rs
+++ b/air-dsl/src/cli/mod.rs
@@ -1,0 +1,2 @@
+mod transpile;
+pub use transpile::TranspileCmd;

--- a/air-dsl/src/cli/transpile.rs
+++ b/air-dsl/src/cli/transpile.rs
@@ -1,0 +1,79 @@
+use std::{fs, path::PathBuf};
+use structopt::StructOpt;
+
+use codegen_winter::CodeGenerator;
+use ir::AirIR;
+use parser::{
+    grammar::SourceParser,
+    lexer::{Lexer, Token},
+};
+
+#[derive(StructOpt, Debug)]
+#[structopt(
+    name = "Transpile",
+    about = "Transpile AIR DSL source code to Rust targeting Winterfell"
+)]
+pub struct TranspileCmd {
+    /// Path to input file
+    #[structopt(short = "i", long = "input", parse(from_os_str))]
+    input_file: Option<PathBuf>,
+    /// Path to output file
+    #[structopt(short = "o", long = "output", parse(from_os_str))]
+    output_file: Option<PathBuf>,
+}
+
+impl TranspileCmd {
+    pub fn execute(&self) -> Result<(), String> {
+        println!("============================================================");
+        println!("Transpiling...");
+
+        // get the input path
+        let input_path = match &self.input_file {
+            Some(path) => path.clone(),
+            None => {
+                return Err("No input file specified".to_string());
+            }
+        };
+
+        // get the output path
+        let output_path = match &self.output_file {
+            Some(path) => path.clone(),
+            None => {
+                let mut path = input_path.clone();
+                path.set_extension("rs");
+                path
+            }
+        };
+
+        // load source input from file
+        let source = fs::read_to_string(input_path).map_err(|err| {
+            format!(
+                "Failed to open input file `{:?}` - {}",
+                &self.input_file, err
+            )
+        })?;
+
+        // scan and parse the input file to the internal representation
+        let lex = Lexer::new(source.as_str()).spanned().map(Token::to_spanned);
+        let parsed = SourceParser::new().parse(lex).unwrap();
+        let ir = AirIR::from_source(&parsed);
+        if let Err(err) = ir {
+            return Err(format!("{:?}", err));
+        }
+        let ir = ir.unwrap();
+
+        // generate Rust code targeting Winterfell
+        let codegen = CodeGenerator::new(&ir);
+
+        // write transpiled output to the output path
+        let result = fs::write(output_path.clone(), codegen.generate());
+        if let Err(err) = result {
+            return Err(format!("{:?}", err));
+        }
+
+        println!("Success! Transpiled to {}", output_path.display());
+        println!("============================================================");
+
+        Ok(())
+    }
+}

--- a/air-dsl/src/main.rs
+++ b/air-dsl/src/main.rs
@@ -1,3 +1,42 @@
-fn main() {
-    println!("Hello, world!");
+use std::io::Write;
+use structopt::StructOpt;
+
+mod cli;
+
+/// Root CLI struct
+#[derive(StructOpt, Debug)]
+#[structopt(name = "AirDsl", about = "AirDsl CLI")]
+pub struct Cli {
+    #[structopt(subcommand)]
+    action: Actions,
+}
+
+/// CLI actions
+#[derive(StructOpt, Debug)]
+pub enum Actions {
+    Transpile(cli::TranspileCmd),
+}
+
+impl Cli {
+    pub fn execute(&self) -> Result<(), String> {
+        match &self.action {
+            Actions::Transpile(transpile) => transpile.execute(),
+        }
+    }
+}
+
+pub fn main() {
+    // configure logging
+    env_logger::Builder::new()
+        .format(|buf, record| writeln!(buf, "{}", record.args()))
+        .filter_level(log::LevelFilter::Debug)
+        .init();
+
+    // read command-line args
+    let cli = Cli::from_args();
+
+    // execute cli action
+    if let Err(error) = cli.execute() {
+        println!("{}", error);
+    }
 }

--- a/codegen-winter/Cargo.toml
+++ b/codegen-winter/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "codegen-winter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+codegen = "0.2.0"
+ir = {package = "ir", path="../ir", version="0.0.1" }

--- a/codegen-winter/src/air/boundary_constraints.rs
+++ b/codegen-winter/src/air/boundary_constraints.rs
@@ -1,0 +1,70 @@
+use super::{AirIR, Impl};
+
+use ir::Expr;
+
+// HELPERS TO GENERATE THE WINTERFELL BOUNDARY CONSTRAINT METHODS
+// ================================================================================================
+
+/// Adds an implementation of the "get_assertions" method to the referenced Air implementation
+/// based on the data in the provided AirIR.
+pub(super) fn add_fn_get_assertions(impl_ref: &mut Impl, ir: &AirIR) {
+    // define the function
+    let get_assertions = impl_ref
+        .new_fn("get_assertions")
+        .arg_ref_self()
+        .ret("Vec<Assertion<Felt>>");
+
+    // declare the result vector to be returned.
+    get_assertions.line("let mut result = Vec::new();");
+
+    // add the constraints for the first boundary
+    for (col_idx, constraint) in ir.main_first_boundary_constraints().iter().enumerate() {
+        let assertion = format!(
+            "result.push(Assertion::single({}, 0, {}));",
+            col_idx,
+            constraint.to_string()
+        );
+        get_assertions.line(assertion);
+    }
+
+    // add the constraints for the last boundary.
+    let last_constraints = ir.main_last_boundary_constraints();
+    if !last_constraints.is_empty() {
+        for (col_idx, constraint) in last_constraints.iter().enumerate() {
+            let assertion = format!(
+                "result.push(Assertion::single({}, 0, {}));",
+                col_idx,
+                constraint.to_string()
+            );
+            get_assertions.line(assertion);
+        }
+    }
+
+    // return the result
+    get_assertions.line("result");
+}
+
+// RUST STRING GENERATION
+// ================================================================================================
+
+/// Code generation trait for generating Rust code strings from boundary constraint expressions.
+trait Codegen {
+    fn to_string(&self) -> String;
+}
+
+impl Codegen for Expr {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Constant(value) => format!("Felt::new({})", value),
+            Self::Add(lhs, rhs) => {
+                format!("{} + {}", lhs.to_string(), rhs.to_string())
+            }
+            Self::Subtract(lhs, rhs) => {
+                format!("{} - {}", lhs.to_string(), rhs.to_string())
+            }
+            _ => {
+                unimplemented!("unreachable code")
+            }
+        }
+    }
+}

--- a/codegen-winter/src/air/mod.rs
+++ b/codegen-winter/src/air/mod.rs
@@ -1,0 +1,112 @@
+use super::{AirIR, Impl, Scope};
+
+mod boundary_constraints;
+use boundary_constraints::add_fn_get_assertions;
+
+mod transition_constraints;
+use transition_constraints::add_fn_evaluate_transition;
+
+// HELPERS TO GENERATE AN IMPLEMENTATION OF THE WINTERFELL AIR TRAIT
+// ================================================================================================
+
+/// Updates the provided scope with a new Air struct and Winterfell Air trait implementation
+/// which are equivalent the provided AirIR.
+pub(super) fn add_air(scope: &mut Scope, ir: &AirIR) {
+    let name = ir.air_name();
+
+    // add the Air struct and its base implementation.
+    add_air_struct(scope, name);
+
+    // add Winterfell Air trait implementation for the provided AirIR.
+    add_air_trait(scope, ir, name);
+}
+
+/// Updates the provided scope with a custom Air struct.
+fn add_air_struct(scope: &mut Scope, name: &str) {
+    // define the custom Air struct.
+    scope
+        .new_struct(name)
+        .vis("pub")
+        .field("context", "AirContext<Felt>");
+
+    // add the custom Air implementation block
+    let base_impl = scope.new_impl(name);
+    // add a simple method to get the last step.
+    base_impl
+        .new_fn("last_step")
+        .vis("pub")
+        .ret("usize")
+        .line("self.trace_length() - self.context().num_transition_exemptions()");
+}
+
+/// Updates the provided scope with the custom Air struct and an Air trait implementation based on
+/// the provided AirIR.
+fn add_air_trait(scope: &mut Scope, ir: &AirIR, name: &str) {
+    // add the implementation block for the Air trait.
+    let air_impl = scope
+        .new_impl(name)
+        .impl_trait("Air")
+        .associate_type("BaseField", "Felt");
+
+    // add default function "context".
+    let fn_context = air_impl
+        .new_fn("context")
+        .arg_ref_self()
+        .ret("&AirContext<Felt>");
+    fn_context.line("&self.context");
+
+    // add the method implementations required by the AIR trait.
+    add_fn_new(air_impl, ir);
+    add_fn_get_assertions(air_impl, ir);
+    add_fn_evaluate_transition(air_impl, ir);
+}
+
+/// Adds an implementation of the "new" method to the referenced Air implementation based on the
+/// data in the provided AirIR.
+fn add_fn_new(impl_ref: &mut Impl, ir: &AirIR) {
+    // define the function.
+    let new = impl_ref
+        .new_fn("new")
+        .arg("trace_info", "TraceInfo")
+        .arg("options", "WinterProofOptions")
+        .ret("Self");
+
+    // define the transition constraint degrees of the main trace `main_degrees`.
+    let mut main_degrees: Vec<String> = Vec::new();
+    for degree in ir.main_degrees().iter() {
+        main_degrees.push(format!("TransitionConstraintDegree::new({})", degree));
+    }
+    new.line(format!(
+        "let main_degrees = vec![{}];",
+        main_degrees.join(",")
+    ));
+
+    // define the transition constraint degrees of the aux trace `aux_degrees`.
+    new.line("let aux_degrees = Vec::new();");
+
+    // define the number of main trace boundary constraints `num_main_assertions`.
+    new.line(format!(
+        "let num_main_assertions = {};",
+        ir.num_main_assertions()
+    ));
+
+    // define the number of aux trace boundary constraints `num_aux_assertions`.
+    new.line("let num_aux_assertions = 0;");
+
+    // define the context.
+    let context = "
+let context = AirContext::new_multi_segment(
+    trace_info,
+    main_degrees,
+    aux_degrees,
+    num_main_assertions,
+    num_aux_assertions,
+    options,
+)
+.set_num_transition_exemptions(2);";
+
+    new.line(context);
+
+    // return initialized Self.
+    new.line("Self { context }");
+}

--- a/codegen-winter/src/air/transition_constraints.rs
+++ b/codegen-winter/src/air/transition_constraints.rs
@@ -1,0 +1,93 @@
+use super::{AirIR, Impl};
+use ir::{
+    transition_constraints::{AlgebraicGraph, Operation},
+    NodeIndex,
+};
+
+// HELPERS TO GENERATE THE WINTERFELL TRANSITION CONSTRAINT METHODS
+// ================================================================================================
+
+/// Adds an implementation of the "evaluate_transition" method to the referenced Air implementation
+/// based on the data in the provided AirIR.
+pub(super) fn add_fn_evaluate_transition(impl_ref: &mut Impl, ir: &AirIR) {
+    // define the function.
+    let evaluate_transition = impl_ref
+        .new_fn("evaluate_transition")
+        .generic("E: FieldElement<BaseField = Felt>")
+        .arg_ref_self()
+        .arg("frame", "&EvaluationFrame<E>")
+        .arg("periodic_values", "&[E]")
+        .arg("result", "&mut [E]");
+
+    // declare current and next trace row arrays.
+    evaluate_transition.line("let current = frame.current();");
+    evaluate_transition.line("let next = frame.next();");
+
+    // output the constraints.
+    let graph = ir.main_transition_graph();
+    for (idx, constraint) in ir.main_transition_constraints().iter().enumerate() {
+        evaluate_transition.line(format!(
+            "result[{}] = {};",
+            idx,
+            constraint.to_string(graph)
+        ));
+    }
+}
+
+// RUST STRING GENERATION
+// ================================================================================================
+
+/// Code generation trait for generating Rust code strings from [AlgebraicGraph] types.
+trait Codegen {
+    fn to_string(&self, graph: &AlgebraicGraph) -> String;
+}
+
+impl Codegen for NodeIndex {
+    fn to_string(&self, graph: &AlgebraicGraph) -> String {
+        let op = graph.node(self).op();
+        op.to_string(graph)
+    }
+}
+
+impl Codegen for Operation {
+    fn to_string(&self, graph: &AlgebraicGraph) -> String {
+        let mut strings = vec![];
+
+        match self {
+            Operation::Constant(value) => strings.push(format!("E::from({})", value)),
+            Operation::MainTraceCurrentRow(col_idx) => {
+                strings.push(format!("current[{}]", col_idx));
+            }
+            Operation::MainTraceNextRow(col_idx) => {
+                strings.push(format!("next[{}]", col_idx));
+            }
+            Operation::Neg(idx) => {
+                strings.push(String::from("-"));
+                let str = idx.to_string(graph);
+                strings.push(str);
+            }
+            Operation::Add(l_idx, r_idx) => {
+                let lhs = l_idx.to_string(graph);
+                strings.push(lhs);
+
+                // output Add followed by Neg as "-"
+                let r_idx = if let Operation::Neg(n_idx) = graph.node(r_idx).op() {
+                    strings.push(String::from("-"));
+                    n_idx
+                } else {
+                    strings.push(String::from("+"));
+                    r_idx
+                };
+
+                let rhs = r_idx.to_string(graph);
+
+                strings.push(rhs);
+            }
+            _ => {
+                // TODO: Mul, Exp
+            }
+        }
+
+        strings.join("")
+    }
+}

--- a/codegen-winter/src/imports.rs
+++ b/codegen-winter/src/imports.rs
@@ -1,0 +1,18 @@
+use super::Scope;
+
+/// Adds the required imports to the provided scope.
+pub(super) fn add_imports(scope: &mut Scope) {
+    // add winterfell imports
+    scope.import(
+        "winter_air::TransitionConstraintDegree",
+        "TransitionConstraintDegree",
+    );
+    scope.import("winter_air::TraceInfo", "TraceInfo");
+    scope.import("winter_air::ProofOptions", "WinterProofOptions");
+    scope.import("winter_air::EvaluationFrame", "EvaluationFrame");
+    scope.import("winter_air::Assertion", "Assertion");
+    scope.import("winter_air::AirContext", "AirContext");
+    scope.import("winter_air::Air", "Air");
+
+    scope.import("winter_utils::collections::Vec", "Vec");
+}

--- a/codegen-winter/src/lib.rs
+++ b/codegen-winter/src/lib.rs
@@ -1,0 +1,42 @@
+use codegen::{Impl, Scope};
+use ir::AirIR;
+
+mod imports;
+use imports::add_imports;
+
+mod air;
+use air::add_air;
+
+// GENERATE RUST CODE FOR WINTERFELL AIR
+// ================================================================================================
+
+/// CodeGenerator is used to generate a Rust implementation of the Winterfell STARK prover library's
+/// Air trait. The generated Air expresses the constraints specified by the AirIR used to build the
+/// CodeGenerator.
+pub struct CodeGenerator {
+    scope: Scope,
+}
+
+impl CodeGenerator {
+    // --- CONSTRUCTOR ----------------------------------------------------------------------------
+
+    /// Builds a new Rust scope that represents a Winterfell Air trait implementation for the
+    /// provided AirIR.
+    pub fn new(ir: &AirIR) -> Self {
+        let mut scope = Scope::new();
+
+        // add winterfell imports.
+        add_imports(&mut scope);
+
+        // add an Air struct and Winterfell Air trait implementation for the provided AirIR.
+        add_air(&mut scope, ir);
+
+        Self { scope }
+    }
+
+    /// Returns a string of Rust code containing a Winterfell Air implementation for the AirIR with
+    /// which this [CodeGenerator] was instantiated.
+    pub fn generate(&self) -> String {
+        self.scope.to_string()
+    }
+}

--- a/examples/system.air
+++ b/examples/system.air
@@ -1,0 +1,10 @@
+def SystemAir
+
+trace_columns:
+    main: [clk, fmp, ctx]
+  
+transition_constraints:
+    enf clk' = clk + 1
+  
+boundary_constraints:
+    enf clk.first = 0

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -8,7 +8,8 @@ pub mod boundary_constraints;
 use boundary_constraints::BoundaryConstraints;
 
 pub mod transition_constraints;
-use transition_constraints::{AlgebraicGraph, NodeIndex, TransitionConstraints};
+pub use transition_constraints::NodeIndex;
+use transition_constraints::{AlgebraicGraph, TransitionConstraints};
 
 mod error;
 use error::SemanticError;


### PR DESCRIPTION
This PR adds a first pass at codegen of a Winterfell Air implementation based on the provided AirIR and a CLI for transpiling `.air` files. It's intended as a framework to give us a full compilation pipeline to build on.

Not included:
- complete codegen (i.e. some imports may be missing, and the output rust code has not been fully validated)
- codegen tests
- formatting of output code