### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, repoened, synchronize]
+
+jobs:
+  test:
+    name: Test Rust ${{matrix.toolchain}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+        os: [ubuntu]
+    steps:
+      - uses: actions/checkout@main
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{matrix.toolchain}}
+          override: true
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install minimal stable with clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all -- -D clippy::all -D warnings
+
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Install minimal stable with rustfmt
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - name: rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -1,4 +1,4 @@
-lalrpop_mod!(pub grammar);
+lalrpop_mod!(grammar, "/parser/grammar.rs");
 
 pub use grammar::SourceParser;
 

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::all)]
 lalrpop_mod!(grammar, "/parser/grammar.rs");
 
 pub use grammar::SourceParser;


### PR DESCRIPTION
This PR adds a basic CI workflow for pull requests to run clippy, rustfmt, and tests. It also includes a commit with a fix to the path for LALRPOP parser generation.

I've left adding the contributing doc until after we finish v0.1 and begin working off the `next` branch.