### PR TITLE
Parser refactor and small bug fixes

### DIFF
--- a/codegen-winter/src/air/boundary_constraints.rs
+++ b/codegen-winter/src/air/boundary_constraints.rs
@@ -29,9 +29,10 @@ pub(super) fn add_fn_get_assertions(impl_ref: &mut Impl, ir: &AirIR) {
     // add the constraints for the last boundary.
     let last_constraints = ir.main_last_boundary_constraints();
     if !last_constraints.is_empty() {
+        get_assertions.line("let last_step = self.last_step();");
         for (col_idx, constraint) in last_constraints.iter().enumerate() {
             let assertion = format!(
-                "result.push(Assertion::single({}, 0, {}));",
+                "result.push(Assertion::single({}, last_step, {}));",
                 col_idx,
                 constraint.to_string()
             );

--- a/codegen-winter/src/air/boundary_constraints.rs
+++ b/codegen-winter/src/air/boundary_constraints.rs
@@ -1,6 +1,5 @@
 use super::{AirIR, Impl};
-
-use ir::Expr;
+use ir::BoundaryExpr;
 
 // HELPERS TO GENERATE THE WINTERFELL BOUNDARY CONSTRAINT METHODS
 // ================================================================================================
@@ -52,7 +51,7 @@ trait Codegen {
     fn to_string(&self) -> String;
 }
 
-impl Codegen for Expr {
+impl Codegen for BoundaryExpr {
     fn to_string(&self) -> String {
         match self {
             Self::Const(value) => format!("Felt::new({})", value),
@@ -67,9 +66,6 @@ impl Codegen for Expr {
             }
             Self::Exp(lhs, rhs) => {
                 format!("({}).exp({})", lhs.to_string(), rhs)
-            }
-            _ => {
-                unimplemented!("unreachable code")
             }
         }
     }

--- a/codegen-winter/src/air/boundary_constraints.rs
+++ b/codegen-winter/src/air/boundary_constraints.rs
@@ -53,17 +53,18 @@ trait Codegen {
 }
 
 impl Codegen for BoundaryExpr {
+    // TODO: Only add parentheses in Add/Sub/Mul/Exp if the expression is an arithmetic operation.
     fn to_string(&self) -> String {
         match self {
             Self::Const(value) => format!("Felt::new({})", value),
             Self::Add(lhs, rhs) => {
-                format!("{} + {}", lhs.to_string(), rhs.to_string())
+                format!("({}) + ({})", lhs.to_string(), rhs.to_string())
             }
             Self::Sub(lhs, rhs) => {
-                format!("{} - {}", lhs.to_string(), rhs.to_string())
+                format!("({}) - ({})", lhs.to_string(), rhs.to_string())
             }
             Self::Mul(lhs, rhs) => {
-                format!("{} * {}", lhs.to_string(), rhs.to_string())
+                format!("({}) * ({})", lhs.to_string(), rhs.to_string())
             }
             Self::Exp(lhs, rhs) => {
                 format!("({}).exp({})", lhs.to_string(), rhs)

--- a/ir/src/boundary_constraints.rs
+++ b/ir/src/boundary_constraints.rs
@@ -1,7 +1,6 @@
-use std::collections::BTreeMap;
-
-use super::{Expr, Identifier, SemanticError, TraceColumns};
+use super::{BoundaryExpr, SemanticError, TraceColumns};
 use parser::ast;
+use std::collections::BTreeMap;
 
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
@@ -14,10 +13,10 @@ use parser::ast;
 pub(crate) struct BoundaryConstraints {
     /// The boundary constraints to be applied at the first row of the trace, with the trace column
     /// index as the key, and the expression as the value.
-    first: BTreeMap<usize, Expr>,
+    first: BTreeMap<usize, BoundaryExpr>,
     /// The boundary constraints to be applied at the last row of the trace, with the trace column
     /// index as the key, and the expression as the value.
-    last: BTreeMap<usize, Expr>,
+    last: BTreeMap<usize, BoundaryExpr>,
 }
 
 impl BoundaryConstraints {
@@ -29,12 +28,12 @@ impl BoundaryConstraints {
     }
 
     /// Returns all of the boundary constraints for the first row of the trace.
-    pub fn first(&self) -> Vec<&Expr> {
+    pub fn first(&self) -> Vec<&BoundaryExpr> {
         self.first.values().collect()
     }
 
     /// Returns all of the boundary constraints for the final row of the trace.
-    pub fn last(&self) -> Vec<&Expr> {
+    pub fn last(&self) -> Vec<&BoundaryExpr> {
         self.last.values().collect()
     }
 
@@ -52,15 +51,6 @@ impl BoundaryConstraints {
     ) -> Result<(), SemanticError> {
         let col_idx = trace_columns.get_column_index(constraint.column())?;
         let value = constraint.value();
-
-        if let Expr::Next(Identifier(ident)) | Expr::Var(Identifier(ident)) = value {
-            // since variable definitions are not possible yet, all parsed identifiers can be
-            // assumed to reference trace columns
-            return Err(SemanticError::InvalidIdentifier(format!(
-                "Column identifier '{}' referenced in boundary constraint",
-                ident
-            )));
-        }
 
         // add the constraint to the specified boundary
         match constraint.boundary() {

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -1,5 +1,5 @@
 use parser::ast;
-pub use parser::ast::{Expr, Identifier};
+pub use parser::ast::{BoundaryExpr, Identifier};
 
 mod trace_columns;
 use trace_columns::TraceColumns;
@@ -85,11 +85,11 @@ impl AirIR {
         self.main_boundary_constraints.len()
     }
 
-    pub fn main_first_boundary_constraints(&self) -> Vec<&Expr> {
+    pub fn main_first_boundary_constraints(&self) -> Vec<&BoundaryExpr> {
         self.main_boundary_constraints.first()
     }
 
-    pub fn main_last_boundary_constraints(&self) -> Vec<&Expr> {
+    pub fn main_last_boundary_constraints(&self) -> Vec<&BoundaryExpr> {
         self.main_boundary_constraints.last()
     }
 

--- a/ir/src/transition_constraints/graph.rs
+++ b/ir/src/transition_constraints/graph.rs
@@ -1,6 +1,6 @@
 use super::TraceColumns;
 use crate::error::SemanticError;
-use parser::ast::{self, Expr, Identifier};
+use parser::ast::{self, Identifier, TransitionExpr};
 
 // ALGEBRAIC GRAPH
 // ================================================================================================
@@ -51,31 +51,31 @@ impl AlgebraicGraph {
     /// recursively to reuse existing matching nodes.
     pub(super) fn insert_expr(
         &mut self,
-        expr: ast::Expr,
+        expr: ast::TransitionExpr,
         trace_columns: &TraceColumns,
     ) -> Result<NodeIndex, SemanticError> {
         match expr {
-            Expr::Const(value) => Ok(self.insert_op(Operation::Const(value))),
-            Expr::Next(Identifier(ident)) => {
+            TransitionExpr::Const(value) => Ok(self.insert_op(Operation::Const(value))),
+            TransitionExpr::Next(Identifier(ident)) => {
                 let index = trace_columns.get_column_index(&ident)?;
                 // insert the next row column node.
                 Ok(self.insert_op(Operation::MainTraceNextRow(index)))
             }
-            Expr::Var(Identifier(ident)) => {
+            TransitionExpr::Var(Identifier(ident)) => {
                 // since variable definitions are not possible yet, the identifier must match one of
                 // the declared trace columns.
                 let index = trace_columns.get_column_index(&ident)?;
                 // insert the current row column node.
                 Ok(self.insert_op(Operation::MainTraceCurrentRow(index)))
             }
-            Expr::Add(lhs, rhs) => {
+            TransitionExpr::Add(lhs, rhs) => {
                 // add both subexpressions.
                 let lhs = self.insert_expr(*lhs, trace_columns)?;
                 let rhs = self.insert_expr(*rhs, trace_columns)?;
                 // add the expression.
                 Ok(self.insert_op(Operation::Add(lhs, rhs)))
             }
-            Expr::Sub(lhs, rhs) => {
+            TransitionExpr::Sub(lhs, rhs) => {
                 // add both subexpressions.
                 let lhs = self.insert_expr(*lhs, trace_columns)?;
                 let rhs = self.insert_expr(*rhs, trace_columns)?;
@@ -84,14 +84,14 @@ impl AlgebraicGraph {
                 // add the expression.
                 Ok(self.insert_op(Operation::Add(lhs, rhs)))
             }
-            Expr::Mul(lhs, rhs) => {
+            TransitionExpr::Mul(lhs, rhs) => {
                 // add both subexpressions.
                 let lhs = self.insert_expr(*lhs, trace_columns)?;
                 let rhs = self.insert_expr(*rhs, trace_columns)?;
                 // add the expression.
                 Ok(self.insert_op(Operation::Mul(lhs, rhs)))
             }
-            Expr::Exp(lhs, rhs) => {
+            TransitionExpr::Exp(lhs, rhs) => {
                 // add base subexpression.
                 let lhs = self.insert_expr(*lhs, trace_columns)?;
                 // add exponent subexpression.

--- a/parser/src/ast/boundary_constraints.rs
+++ b/parser/src/ast/boundary_constraints.rs
@@ -1,4 +1,4 @@
-use super::{Expr, Identifier};
+use super::Identifier;
 
 // BOUNDARY CONSTRAINTS
 // ================================================================================================
@@ -14,11 +14,11 @@ pub struct BoundaryConstraints {
 pub struct BoundaryConstraint {
     column: Identifier,
     boundary: Boundary,
-    value: Expr,
+    value: BoundaryExpr,
 }
 
 impl BoundaryConstraint {
-    pub fn new(column: Identifier, boundary: Boundary, value: Expr) -> Self {
+    pub fn new(column: Identifier, boundary: Boundary, value: BoundaryExpr) -> Self {
         Self {
             column,
             boundary,
@@ -35,7 +35,7 @@ impl BoundaryConstraint {
     }
 
     /// Returns a clone of the constraint's value expression.
-    pub fn value(&self) -> Expr {
+    pub fn value(&self) -> BoundaryExpr {
         self.value.clone()
     }
 }
@@ -45,4 +45,14 @@ impl BoundaryConstraint {
 pub enum Boundary {
     First,
     Last,
+}
+
+/// Arithmetic expressions for evaluation of boundary constraints.
+#[derive(Debug, PartialEq, Clone)]
+pub enum BoundaryExpr {
+    Const(u64),
+    Add(Box<BoundaryExpr>, Box<BoundaryExpr>),
+    Sub(Box<BoundaryExpr>, Box<BoundaryExpr>),
+    Mul(Box<BoundaryExpr>, Box<BoundaryExpr>),
+    Exp(Box<BoundaryExpr>, u64),
 }

--- a/parser/src/ast/mod.rs
+++ b/parser/src/ast/mod.rs
@@ -40,17 +40,8 @@ pub struct TraceCols {
     pub aux_cols: Vec<Identifier>,
 }
 
-/// Arithmetic expressions for constraint evaluation.
-#[derive(Debug, PartialEq, Clone)]
-pub enum Expr {
-    Const(u64),
-    Var(Identifier),
-    Next(Identifier),
-    Add(Box<Expr>, Box<Expr>),
-    Sub(Box<Expr>, Box<Expr>),
-    Mul(Box<Expr>, Box<Expr>),
-    Exp(Box<Expr>, u64),
-}
+// SHARED ATOMIC TYPES
+// ================================================================================================
 
 /// [Identifier] is used to represent variable names.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone)]

--- a/parser/src/ast/transition_constraints.rs
+++ b/parser/src/ast/transition_constraints.rs
@@ -1,4 +1,4 @@
-use super::Expr;
+use super::Identifier;
 
 // TRANSITION CONSTRAINTS
 // ================================================================================================
@@ -12,18 +12,30 @@ pub struct TransitionConstraints {
 /// Stores the expression corresponding to the transition constraint.
 #[derive(Debug, PartialEq, Clone)]
 pub struct TransitionConstraint {
-    lhs: Expr,
-    rhs: Expr,
+    lhs: TransitionExpr,
+    rhs: TransitionExpr,
 }
 
 impl TransitionConstraint {
-    pub fn new(lhs: Expr, rhs: Expr) -> Self {
+    pub fn new(lhs: TransitionExpr, rhs: TransitionExpr) -> Self {
         Self { lhs, rhs }
     }
 
     /// Clones the left and right internal expressions and creates a single new expression that
     /// represents the transition constraint when it is equal to zero.
-    pub fn expr(&self) -> Expr {
-        Expr::Sub(Box::new(self.lhs.clone()), Box::new(self.rhs.clone()))
+    pub fn expr(&self) -> TransitionExpr {
+        TransitionExpr::Sub(Box::new(self.lhs.clone()), Box::new(self.rhs.clone()))
     }
+}
+
+/// Arithmetic expressions for evaluation of transition constraints.
+#[derive(Debug, PartialEq, Clone)]
+pub enum TransitionExpr {
+    Const(u64),
+    Var(Identifier),
+    Next(Identifier),
+    Add(Box<TransitionExpr>, Box<TransitionExpr>),
+    Sub(Box<TransitionExpr>, Box<TransitionExpr>),
+    Mul(Box<TransitionExpr>, Box<TransitionExpr>),
+    Exp(Box<TransitionExpr>, u64),
 }

--- a/parser/src/parser/grammar.lalrpop
+++ b/parser/src/parser/grammar.lalrpop
@@ -1,7 +1,6 @@
 use crate::{
     ast::{
-        Boundary, BoundaryConstraints, BoundaryConstraint, TransitionConstraint, Expr,
-        Identifier, Source, SourceSection, TraceCols, TransitionConstraints
+        Boundary, BoundaryConstraints, BoundaryConstraint, BoundaryExpr, Identifier, Source, SourceSection,TransitionConstraint, TransitionConstraints, TransitionExpr, TraceCols,
     }, error::{Error, ParseError::{InvalidInt, InvalidTraceCols}}, lexer::Token
 };
 use std::str::FromStr;
@@ -62,13 +61,32 @@ BoundaryConstraints: BoundaryConstraints = {
 }
 
 BoundaryConstraint: BoundaryConstraint = {
-    "enf" <column: Identifier> "." <boundary: Boundary> "=" <value: Expr> =>
+    "enf" <column: Identifier> "." <boundary: Boundary> "=" <value: BoundaryExpr> =>
         BoundaryConstraint::new(column, boundary, value)
 }
 
 Boundary: Boundary = {
     "first" => Boundary::First,
     "last" => Boundary::Last
+}
+
+// --- BOUNDARY CONSTRAINT EXPRESSIONS WITH PRECEDENCE (LOWEST TO HIGHEST) ----------------------
+
+BoundaryExpr: BoundaryExpr = {
+    <lexpr: BoundaryExpr> "+" <rexpr: BoundaryFactor> => BoundaryExpr::Add(Box::new(lexpr), Box::new(rexpr)),
+    <lexpr: BoundaryExpr> "-" <rexpr: BoundaryFactor> => BoundaryExpr::Sub(Box::new(lexpr), Box::new(rexpr)),
+    BoundaryFactor
+}
+
+BoundaryFactor: BoundaryExpr = {
+    <lexpr: BoundaryFactor> "*" <rexpr: BoundaryAtom> => BoundaryExpr::Mul(Box::new(lexpr), Box::new(rexpr)),
+    BoundaryAtom
+}
+
+BoundaryAtom: BoundaryExpr = {
+    "(" <BoundaryExpr> ")",
+    <lexpr: BoundaryAtom> "^" <num: Num> => BoundaryExpr::Exp(Box::new(lexpr), num),
+    <n: Num> => BoundaryExpr::Const(n),
 }
 
 // TRANSITION CONSTRAINTS
@@ -80,41 +98,28 @@ TransitionConstraints: TransitionConstraints = {
 }
 
 TransitionConstraint: TransitionConstraint = {
-    "enf" <lhs: Expr> "=" <rhs: Expr> => TransitionConstraint::new(lhs, rhs)
+    "enf" <lhs: TransitionExpr> "=" <rhs: TransitionExpr> => TransitionConstraint::new(lhs, rhs)
 }
 
-// EXPRESSIONS WITH PRECEDENCE (LOWEST TO HIGHEST)
-// ================================================================================================
+// --- TRANSITION CONSTRAINT EXPRESSIONS WITH PRECEDENCE (LOWEST TO HIGHEST) ----------------------
 
-Expr: Expr = {
-    <lexpr: Expr> "+" <rexpr: FactorExpr> => Expr::Add(Box::new(lexpr), Box::new(rexpr)),
-    <lexpr: Expr> "-" <rexpr: FactorExpr> => Expr::Sub(Box::new(lexpr), Box::new(rexpr)),
-    FactorExpr
+TransitionExpr: TransitionExpr = {
+    <lexpr: TransitionExpr> "+" <rexpr: TransitionFactor> => TransitionExpr::Add(Box::new(lexpr), Box::new(rexpr)),
+    <lexpr: TransitionExpr> "-" <rexpr: TransitionFactor> => TransitionExpr::Sub(Box::new(lexpr), Box::new(rexpr)),
+    TransitionFactor
 }
 
-FactorExpr: Expr = {
-    <lexpr: FactorExpr> "*" <rexpr: ExpExpr> => Expr::Mul(Box::new(lexpr), Box::new(rexpr)),
-    ExpExpr
+TransitionFactor: TransitionExpr = {
+    <lexpr: TransitionFactor> "*" <rexpr: TransitionAtom> => TransitionExpr::Mul(Box::new(lexpr), Box::new(rexpr)),
+    TransitionAtom
 }
 
-ExpExpr: Expr = {
-    <lexpr: ExpExpr> "^" <num: Num> => Expr::Exp(Box::new(lexpr), num),
-    ParenExpr
-}
-
-ParenExpr: Expr = {
-    "(" <Expr> ")",
-    NextExpr
-}
-
-NextExpr: Expr = {
-    <s: Identifier> "'" => Expr::Next(s),
-    AtomExpr
-}
-
-AtomExpr: Expr = {
-    <n: Num> => Expr::Const(n),
-    <s: Identifier> => Expr::Var(s),
+TransitionAtom: TransitionExpr = {
+    "(" <TransitionExpr> ")",
+    <lexpr: TransitionAtom> "^" <num: Num> => TransitionExpr::Exp(Box::new(lexpr), num),
+    <n: Num> => TransitionExpr::Const(n),
+    <s: Identifier> => TransitionExpr::Var(s),
+    <s: Identifier> "'" => TransitionExpr::Next(s),
 }
 
 // ATOMS

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_parse_test, Boundary, BoundaryConstraint, BoundaryConstraints, Expr, Identifier, Source,
-    SourceSection,
+    build_parse_test, Boundary, BoundaryConstraint, BoundaryConstraints, BoundaryExpr, Identifier,
+    Source, SourceSection,
 };
 
 // SECTIONS
@@ -16,7 +16,7 @@ fn boundary_constraints() {
             boundary_constraints: vec![BoundaryConstraint::new(
                 Identifier("clk".to_string()),
                 Boundary::First,
-                Expr::Const(0),
+                BoundaryExpr::Const(0),
             )],
         },
     )]);
@@ -35,12 +35,12 @@ fn multiple_boundary_constraints() {
                 BoundaryConstraint::new(
                     Identifier("clk".to_string()),
                     Boundary::First,
-                    Expr::Const(0),
+                    BoundaryExpr::Const(0),
                 ),
                 BoundaryConstraint::new(
                     Identifier("clk".to_string()),
                     Boundary::Last,
-                    Expr::Const(1),
+                    BoundaryExpr::Const(1),
                 ),
             ],
         },

--- a/parser/src/parser/tests/expressions.rs
+++ b/parser/src/parser/tests/expressions.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_parse_test, Expr, Identifier, Source, SourceSection, TransitionConstraint,
-    TransitionConstraints,
+    build_parse_test, Identifier, Source, SourceSection, TransitionConstraint,
+    TransitionConstraints, TransitionExpr,
 };
 
 // EXPRESSIONS
@@ -15,11 +15,11 @@ fn single_addition() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Add(
-                    Box::new(Expr::Next(Identifier("clk".to_string()))),
-                    Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Add(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);
@@ -35,14 +35,14 @@ fn multi_addition() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Add(
-                    Box::new(Expr::Add(
-                        Box::new(Expr::Next(Identifier("clk".to_string()))),
-                        Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Add(
+                    Box::new(TransitionExpr::Add(
+                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                     )),
-                    Box::new(Expr::Const(2)),
+                    Box::new(TransitionExpr::Const(2)),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);
@@ -58,11 +58,11 @@ fn single_subtraction() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Sub(
-                    Box::new(Expr::Next(Identifier("clk".to_string()))),
-                    Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Sub(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);
@@ -78,14 +78,14 @@ fn multi_subtraction() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Sub(
-                    Box::new(Expr::Sub(
-                        Box::new(Expr::Next(Identifier("clk".to_string()))),
-                        Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Sub(
+                    Box::new(TransitionExpr::Sub(
+                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                     )),
-                    Box::new(Expr::Const(1)),
+                    Box::new(TransitionExpr::Const(1)),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);
@@ -101,11 +101,11 @@ fn single_multiplication() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Mul(
-                    Box::new(Expr::Next(Identifier("clk".to_string()))),
-                    Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Mul(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);
@@ -121,14 +121,34 @@ fn multi_multiplication() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Mul(
-                    Box::new(Expr::Mul(
-                        Box::new(Expr::Next(Identifier("clk".to_string()))),
-                        Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Mul(
+                    Box::new(TransitionExpr::Mul(
+                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                     )),
-                    Box::new(Expr::Const(2)),
+                    Box::new(TransitionExpr::Const(2)),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
+            )],
+        },
+    )]);
+    build_parse_test!(source).expect_ast(expected);
+}
+
+#[test]
+fn unit_with_parens() {
+    // the operation must be put into a source section, or parsing will fail
+    let source = "
+    transition_constraints:
+        enf (2) + 1 = 3";
+    let expected = Source(vec![SourceSection::TransitionConstraints(
+        TransitionConstraints {
+            transition_constraints: vec![TransitionConstraint::new(
+                TransitionExpr::Add(
+                    Box::new(TransitionExpr::Const(2)),
+                    Box::new(TransitionExpr::Const(1)),
+                ),
+                TransitionExpr::Const(3),
             )],
         },
     )]);
@@ -144,14 +164,14 @@ fn ops_with_parens() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Mul(
-                    Box::new(Expr::Add(
-                        Box::new(Expr::Next(Identifier("clk".to_string()))),
-                        Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Mul(
+                    Box::new(TransitionExpr::Add(
+                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                     )),
-                    Box::new(Expr::Const(2)),
+                    Box::new(TransitionExpr::Const(2)),
                 ),
-                Expr::Const(4),
+                TransitionExpr::Const(4),
             )],
         },
     )]);
@@ -167,8 +187,11 @@ fn single_exponentiation() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Exp(Box::new(Expr::Next(Identifier("clk".to_string()))), 2),
-                Expr::Const(1),
+                TransitionExpr::Exp(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    2,
+                ),
+                TransitionExpr::Const(1),
             )],
         },
     )]);
@@ -211,17 +234,17 @@ fn multi_arithmetic_ops_same_precedence() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Add(
-                    Box::new(Expr::Sub(
-                        Box::new(Expr::Sub(
-                            Box::new(Expr::Next(Identifier("clk".to_string()))),
-                            Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Add(
+                    Box::new(TransitionExpr::Sub(
+                        Box::new(TransitionExpr::Sub(
+                            Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                            Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                         )),
-                        Box::new(Expr::Const(2)),
+                        Box::new(TransitionExpr::Const(2)),
                     )),
-                    Box::new(Expr::Const(1)),
+                    Box::new(TransitionExpr::Const(1)),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);
@@ -242,20 +265,20 @@ fn multi_arithmetic_ops_different_precedence() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Sub(
-                    Box::new(Expr::Sub(
-                        Box::new(Expr::Exp(
-                            Box::new(Expr::Next(Identifier("clk".to_string()))),
+                TransitionExpr::Sub(
+                    Box::new(TransitionExpr::Sub(
+                        Box::new(TransitionExpr::Exp(
+                            Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
                             2,
                         )),
-                        Box::new(Expr::Mul(
-                            Box::new(Expr::Var(Identifier("clk".to_string()))),
-                            Box::new(Expr::Const(2)),
+                        Box::new(TransitionExpr::Mul(
+                            Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                            Box::new(TransitionExpr::Const(2)),
                         )),
                     )),
-                    Box::new(Expr::Const(1)),
+                    Box::new(TransitionExpr::Const(1)),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);
@@ -277,20 +300,20 @@ fn multi_arithmetic_ops_different_precedence_w_parens() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Sub(
-                    Box::new(Expr::Next(Identifier("clk".to_string()))),
-                    Box::new(Expr::Mul(
-                        Box::new(Expr::Exp(
-                            Box::new(Expr::Var(Identifier("clk".to_string()))),
+                TransitionExpr::Sub(
+                    Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Mul(
+                        Box::new(TransitionExpr::Exp(
+                            Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                             2,
                         )),
-                        Box::new(Expr::Sub(
-                            Box::new(Expr::Const(2)),
-                            Box::new(Expr::Const(1)),
+                        Box::new(TransitionExpr::Sub(
+                            Box::new(TransitionExpr::Const(2)),
+                            Box::new(TransitionExpr::Const(1)),
                         )),
                     )),
                 ),
-                Expr::Const(0),
+                TransitionExpr::Const(0),
             )],
         },
     )]);

--- a/parser/src/parser/tests/identifiers.rs
+++ b/parser/src/parser/tests/identifiers.rs
@@ -1,6 +1,7 @@
 use super::{build_parse_test, Error, ParseError};
 
-// PARSE ERRORS
+// TODO: clean up this test file
+// IDENTIFIERS
 // ================================================================================================
 
 #[test]

--- a/parser/src/parser/tests/mod.rs
+++ b/parser/src/parser/tests/mod.rs
@@ -42,10 +42,10 @@ fn full_air_file() {
         SourceSection::TransitionConstraints(TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
                 // clk' = clk + 1
-                Expr::Next(Identifier("clk".to_string())),
-                Expr::Add(
-                    Box::new(Expr::Var(Identifier("clk".to_string()))),
-                    Box::new(Expr::Const(1)),
+                TransitionExpr::Next(Identifier("clk".to_string())),
+                TransitionExpr::Add(
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Const(1)),
                 ),
             )],
         }),
@@ -55,7 +55,7 @@ fn full_air_file() {
             boundary_constraints: vec![BoundaryConstraint::new(
                 Identifier("clk".to_string()),
                 Boundary::First,
-                Expr::Const(0),
+                BoundaryExpr::Const(0),
             )],
         }),
     ]);

--- a/parser/src/parser/tests/trace_columns.rs
+++ b/parser/src/parser/tests/trace_columns.rs
@@ -1,6 +1,6 @@
 use super::{build_parse_test, Error, Identifier, ParseError, Source, SourceSection, TraceCols};
 
-// SECTIONS
+// TRACE COLUMNS
 // ================================================================================================
 
 #[test]

--- a/parser/src/parser/tests/transition_constraints.rs
+++ b/parser/src/parser/tests/transition_constraints.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_parse_test, Expr, Identifier, Source, SourceSection, TransitionConstraint,
-    TransitionConstraints,
+    build_parse_test, Identifier, Source, SourceSection, TransitionConstraint,
+    TransitionConstraints, TransitionExpr,
 };
 
 // SECTIONS
@@ -14,10 +14,10 @@ fn transition_constraints() {
     let expected = Source(vec![SourceSection::TransitionConstraints(
         TransitionConstraints {
             transition_constraints: vec![TransitionConstraint::new(
-                Expr::Next(Identifier("clk".to_string())),
-                Expr::Add(
-                    Box::new(Expr::Var(Identifier("clk".to_string()))),
-                    Box::new(Expr::Const(1)),
+                TransitionExpr::Next(Identifier("clk".to_string())),
+                TransitionExpr::Add(
+                    Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                    Box::new(TransitionExpr::Const(1)),
                 ),
             )],
         },
@@ -42,18 +42,18 @@ fn multiple_transition_constraints() {
         TransitionConstraints {
             transition_constraints: vec![
                 TransitionConstraint::new(
-                    Expr::Next(Identifier("clk".to_string())),
-                    Expr::Add(
-                        Box::new(Expr::Var(Identifier("clk".to_string()))),
-                        Box::new(Expr::Const(1)),
+                    TransitionExpr::Next(Identifier("clk".to_string())),
+                    TransitionExpr::Add(
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Const(1)),
                     ),
                 ),
                 TransitionConstraint::new(
-                    Expr::Sub(
-                        Box::new(Expr::Next(Identifier("clk".to_string()))),
-                        Box::new(Expr::Var(Identifier("clk".to_string()))),
+                    TransitionExpr::Sub(
+                        Box::new(TransitionExpr::Next(Identifier("clk".to_string()))),
+                        Box::new(TransitionExpr::Var(Identifier("clk".to_string()))),
                     ),
-                    Expr::Const(1),
+                    TransitionExpr::Const(1),
                 ),
             ],
         },

--- a/parser/src/parser/tests/transition_constraints.rs
+++ b/parser/src/parser/tests/transition_constraints.rs
@@ -3,7 +3,7 @@ use super::{
     TransitionConstraints, TransitionExpr,
 };
 
-// SECTIONS
+// TRANSITION CONSTRAINTS
 // ================================================================================================
 
 #[test]


### PR DESCRIPTION
This PR addresses a few minor fixes and refactors the expressions in the parser to separate boundary and transition expressions in preparation for adding the remaining v0.1 features (public inputs, periodic columns, auxiliary trace handling, and random values)