### PR TITLE
Examples for testing and demonstration

### DIFF
--- a/examples/aux_trace.air
+++ b/examples/aux_trace.air
@@ -1,0 +1,25 @@
+def AuxiliaryAir
+
+trace_columns:
+    main: [a, b, c]
+    aux: [p0, p1]
+  
+boundary_constraints:
+    enf a.first = 1
+    enf b.first = 1
+
+    enf p0.first = 1
+    enf p0.last = 1
+
+    # auxiliary boundary constraint with a random value
+    enf p1.first = $rand[0]
+    enf p1.last = 1
+  
+transition_constraints:
+    enf a' = b + c
+    enf b' = c + a'
+    enf c = a + b
+
+    # transition constraints against the auxiliary trace with random values
+    enf p0' = p0 * (a + $rand[0] + b + $rand[1])
+    enf p1 = p1' * (c + $rand[0])

--- a/examples/binary.air
+++ b/examples/binary.air
@@ -1,0 +1,8 @@
+def BinaryAir
+
+trace_columns:
+    main: [a, b]
+
+transition_constraints:
+    enf a^2 - a = 0
+    enf b^2 - b = 0

--- a/examples/bitwise.air
+++ b/examples/bitwise.air
@@ -1,0 +1,47 @@
+def BitwiseAir
+
+trace_columns:
+    main: [s, a0, b0, a[4], b[4], zp, z]
+
+periodic_columns:
+    k0: [1, 0, 0, 0, 0, 0, 0, 0]
+    k1: [1, 1, 1, 1, 1, 1, 1, 0]
+
+transition_constraints:
+    # Enforce that selector must be binary
+    enf s^2 - s = 0
+
+    # Enforce that selector should stay the same throughout
+    enf k1 * (s' - s) = 0
+
+    # Enforce that input is decomposed into valid bits
+    for i in 0..4:
+        enf a[i]^2 - a[i] = 0
+        enf b[i]^2 - b[i] = 0
+
+    # Enforce that the values in the columns a0 and b0 are exactly equal to the aggregation of binary
+    # values contained in the individual bit columns.
+    enf k0 * (a0 - sum([2^i * a[i] for i in range(0, 4)])) = 0
+    enf k0 * (b0 - sum([2^i * b[i] for i in range(0, 4)])) = 0
+
+    # Enforce that for all rows in an 8-row cycle except for the last one, the values in a0 and b0
+    # columns are increased by the values contained in the individual bit columns a and b.
+    enf k1 * (a0' - (a0 * 16 + sum([2^i * a[i] for i in range(0, 4)]))) = 0
+    enf k1 * (b0' - (b0 * 16 + sum([2^i * b[i] for i in range(0, 4)]))) = 0
+
+    # Enforce that in the first row, the aggregated output value of the previous row should be 0.
+    enf k0 * zp = 0
+
+    # Enforce that for each row except the last, the aggregated output value must equal the previous
+    # aggregated output value in the next row.
+    enf k1 * (z - zp') = 0
+
+    # Enforce that for all rows the value in the z column is computed by multiplying the previous
+    # output value (from the zp column in the current row) by 16 and then adding it to the bitwise
+    # operation applied to the row's set of bits of a and b. The entire constraint must also be
+    # multiplied by the operation selector flag to ensure it is only applied for the appropriate
+    # operation.
+    let u32and_constraint = (1 - s) * (z - (zp * 16 + sum([2^i * a[i] * b[i] for i in range(0, 4)])))
+    let u32xor_constraint = s * (z - (zp * 16 + sum([a[i] + b[i] - 2^i * a[i] * b[i] for i in range(0, 4)])))
+    
+    enf u32and_constraint + u32xor_constraint = 0

--- a/examples/periodic_columns.air
+++ b/examples/periodic_columns.air
@@ -1,0 +1,12 @@
+def PeriodicColumnsAir
+
+trace_columns:
+    main: [a, b, c]
+
+periodic_columns:
+    k0: [1, 0, 0, 0]
+    k1: [1, 1, 1, 1, 1, 1, 1, 0]
+
+transition_constraints:
+    enf k0 * (b + c) = 0
+    enf k1 * (a' - a) = 0

--- a/examples/pub_inputs.air
+++ b/examples/pub_inputs.air
@@ -1,0 +1,21 @@
+def PubInputsAir
+
+trace_columns:
+  main: [a, b, c, d]
+
+public_inputs:
+  program_hash: [4]
+  stack_inputs: [4]
+  stack_outputs: [20]
+  overflow_addrs: [4]
+  
+boundary_constraints:
+  enf a.first = stack_inputs[0]
+  enf b.first = stack_inputs[1]
+  enf c.first = stack_inputs[2]
+  enf d.first = stack_inputs[3]
+
+  enf a.last = stack_outputs[0]
+  enf b.last = stack_outputs[1]
+  enf c.last = stack_outputs[2]
+  enf d.last = stack_outputs[3]


### PR DESCRIPTION
This PR adds simple example AIR definitions to the `examples` directory for binary constraints, public inputs, periodic columns, and constraints against the auxiliary trace using random values.

They can be used for demonstration purposes with the CLI or for testing for #16.