### PR TITLE
fix: return column index for boundary conditions from accessors

### DIFF
--- a/codegen-winter/src/air/boundary_constraints.rs
+++ b/codegen-winter/src/air/boundary_constraints.rs
@@ -17,7 +17,7 @@ pub(super) fn add_fn_get_assertions(impl_ref: &mut Impl, ir: &AirIR) {
     get_assertions.line("let mut result = Vec::new();");
 
     // add the constraints for the first boundary
-    for (col_idx, constraint) in ir.main_first_boundary_constraints().iter().enumerate() {
+    for (col_idx, constraint) in ir.main_first_boundary_constraints() {
         let assertion = format!(
             "result.push(Assertion::single({}, 0, {}));",
             col_idx,
@@ -30,7 +30,7 @@ pub(super) fn add_fn_get_assertions(impl_ref: &mut Impl, ir: &AirIR) {
     let last_constraints = ir.main_last_boundary_constraints();
     if !last_constraints.is_empty() {
         get_assertions.line("let last_step = self.last_step();");
-        for (col_idx, constraint) in last_constraints.iter().enumerate() {
+        for (col_idx, constraint) in last_constraints {
             let assertion = format!(
                 "result.push(Assertion::single({}, last_step, {}));",
                 col_idx,

--- a/ir/src/boundary_constraints.rs
+++ b/ir/src/boundary_constraints.rs
@@ -33,13 +33,13 @@ impl BoundaryConstraints {
     }
 
     /// Returns all of the boundary constraints for the first row of the main trace.
-    pub fn main_first(&self) -> Vec<&BoundaryExpr> {
-        self.main_first.values().collect()
+    pub fn main_first(&self) -> Vec<(usize, &BoundaryExpr)> {
+        self.main_first.iter().map(|(k, v)| (*k, v)).collect()
     }
 
     /// Returns all of the boundary constraints for the final row of the main trace.
-    pub fn main_last(&self) -> Vec<&BoundaryExpr> {
-        self.main_last.values().collect()
+    pub fn main_last(&self) -> Vec<(usize, &BoundaryExpr)> {
+        self.main_last.iter().map(|(k, v)| (*k, v)).collect()
     }
 
     /// Returns the total number of boundary constraints for the aux trace.
@@ -48,13 +48,13 @@ impl BoundaryConstraints {
     }
 
     /// Returns all of the boundary constraints for the first row of the aux trace.
-    pub fn aux_first(&self) -> Vec<&BoundaryExpr> {
-        self.aux_first.values().collect()
+    pub fn aux_first(&self) -> Vec<(usize, &BoundaryExpr)> {
+        self.aux_first.iter().map(|(k, v)| (*k, v)).collect()
     }
 
     /// Returns all of the boundary constraints for the final row of the aux trace.
-    pub fn aux_last(&self) -> Vec<&BoundaryExpr> {
-        self.aux_last.values().collect()
+    pub fn aux_last(&self) -> Vec<(usize, &BoundaryExpr)> {
+        self.aux_last.iter().map(|(k, v)| (*k, v)).collect()
     }
 
     // --- MUTATORS -------------------------------------------------------------------------------

--- a/ir/src/lib.rs
+++ b/ir/src/lib.rs
@@ -108,11 +108,11 @@ impl AirIR {
         self.boundary_constraints.main_len()
     }
 
-    pub fn main_first_boundary_constraints(&self) -> Vec<&BoundaryExpr> {
+    pub fn main_first_boundary_constraints(&self) -> Vec<(usize, &BoundaryExpr)> {
         self.boundary_constraints.main_first()
     }
 
-    pub fn main_last_boundary_constraints(&self) -> Vec<&BoundaryExpr> {
+    pub fn main_last_boundary_constraints(&self) -> Vec<(usize, &BoundaryExpr)> {
         self.boundary_constraints.main_last()
     }
 
@@ -120,11 +120,11 @@ impl AirIR {
         self.boundary_constraints.aux_len()
     }
 
-    pub fn aux_first_boundary_constraints(&self) -> Vec<&BoundaryExpr> {
+    pub fn aux_first_boundary_constraints(&self) -> Vec<(usize, &BoundaryExpr)> {
         self.boundary_constraints.aux_first()
     }
 
-    pub fn aux_last_boundary_constraints(&self) -> Vec<&BoundaryExpr> {
+    pub fn aux_last_boundary_constraints(&self) -> Vec<(usize, &BoundaryExpr)> {
         self.boundary_constraints.aux_last()
     }
 


### PR DESCRIPTION
Small fix in the boundary constraints IR. We need the column index for the constraints while accessing it from IR during codegen for setting the column values in assertions. We should return a `Vec<(usize, &BoundaryExpr)>` instead of `Vec<&BoundaryExpr>` from access methods.

I didn't add any tests but tested it with a sample file:

```
trace_columns:
    main: [clk, fmp, ctx]
  
transition_constraints:
    enf clk' = clk + 1
  
boundary_constraints:
    enf clk.first = 0
    enf ctx.first = 0
    enf ctx.last = 1
```
Before fix:
```
let mut result = Vec::new();
result.push(Assertion::single(0, 0, Felt::from(0)));
result.push(Assertion::single(1, 0, Felt::from(0)));
let last_step = self.last_step();
result.push(Assertion::single(0, last_step, Felt::from(1)));
result
```

After fix: 
```
let mut result = Vec::new();
result.push(Assertion::single(0, 0, Felt::from(0)));
result.push(Assertion::single(2, 0, Felt::from(0)));
let last_step = self.last_step();
result.push(Assertion::single(2, last_step, Felt::from(1)));
result
```
