### PR TITLE
Throw error when sections are empty or omitted

### DIFF
--- a/ir/src/error.rs
+++ b/ir/src/error.rs
@@ -6,4 +6,5 @@ pub enum SemanticError {
     IndexOutOfRange(String),
     TooManyConstraints(String),
     InvalidPeriodicColumn(String),
+    MissingSection(String),
 }

--- a/parser/src/parser/tests/boundary_constraints.rs
+++ b/parser/src/parser/tests/boundary_constraints.rs
@@ -122,3 +122,12 @@ fn err_boundary_constraint_with_identifier() {
         enf clk.first = a + 5";
     build_parse_test!(source).expect_unrecognized_token();
 }
+
+#[test]
+fn err_empty_boundary_constraints() {
+    let source = "
+    boundary_constraints:
+    transition_constraints:
+        enf clk' = clk + 1";
+    build_parse_test!(source).expect_unrecognized_token();
+}

--- a/parser/src/parser/tests/transition_constraints.rs
+++ b/parser/src/parser/tests/transition_constraints.rs
@@ -109,3 +109,13 @@ fn error_invalid_next_usage() {
         enf clk'' = clk + 1";
     build_parse_test!(source).expect_unrecognized_token();
 }
+
+#[test]
+fn err_empty_transition_constraints() {
+    let source = "
+    transition_constraints:
+        
+    boundary_constraints:
+        enf clk.first = 1";
+    build_parse_test!(source).expect_unrecognized_token();
+}


### PR DESCRIPTION
Addressing #45, #44 and #30.
- Regarding throwing error when boundary_constraints or transition_constraints are empty, that case was already handled but I have included tests in parser for the same.
- Changes to the docs for transition constraints and boundary constraints are missing in this PR as they should be done after #36 is merged.